### PR TITLE
Fix a typo

### DIFF
--- a/amrex/docs_html/Basics.html
+++ b/amrex/docs_html/Basics.html
@@ -2092,7 +2092,7 @@ section <a class="reference internal" href="GPU.html#sec-gpu-for"><span class="s
 region will be started by the pragma above the <code class="code cpp c++ docutils literal notranslate"><span class="name"><span class="pre">MFIter</span></span></code> loop if it is
 built with OpenMP and without enabling GPU.  Tiling is turned off if
 GPU is enabled so that more parallelism is exposed to GPU kernels.
-Also note that when tiling is off, <code class="code cpp c++ docutils literal notranslate"><span class="name"><span class="pre">tilbox</span></span></code> returns
+Also note that when tiling is off, <code class="code cpp c++ docutils literal notranslate"><span class="name"><span class="pre">tilebox</span></span></code> returns
 <code class="code cpp c++ docutils literal notranslate"><span class="name"><span class="pre">validbox</span></span></code>.</p>
 <p>There are other versions of <code class="code cpp c++ docutils literal notranslate"><span class="name"><span class="pre">ParallelFor</span></span></code>,</p>
 <div class="highlight-c++ notranslate"><div class="highlight"><pre><span></span><span class="c1">// 1D for loop</span>


### PR DESCRIPTION
I fixed a typo that I met while reading.
`tilbox` → `tilebox`